### PR TITLE
Fixup README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ class ApplicationController < ActionController::Base
 
   # or optionally override the method name we use to fetch current_[class_name] e.g.:
   #
-  # authorize_persona class_name: "User", current_user_method_name: :current_fancy_user
+  # authorize_persona class_name: "User", current_user_method: :current_fancy_user
 
   # Your code here...
 end


### PR DESCRIPTION
/domain @samandmoore @smudge @jmileham 
/no-platform

Just noticed a typo, the actual option is `current_user_method`: https://github.com/Betterment/authorized_persona/blob/3c2b6f0860358f21e5efbe1e01a9d9f7cddbc5b0/lib/authorized_persona/authorization.rb#L16