### PR TITLE
Small readme update to reflect correct tier methods for _or_above?

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ class BillSearch
   end
 
   def bills
-    # AuthorizedPersona::Persona provides #[tier]_and_above? methods for all defined tiers
+    # AuthorizedPersona::Persona provides #[tier]_or_above? methods for all defined tiers
     relation = searcher.admin_or_above? ? Bills.all : Bills.nonsensitive
     relation.where('title like ?', query)
   end


### PR DESCRIPTION
The README references`_and_above?` as a method that is defined to help manage the tiers - but it's `_or_above?`.  Small change the make that usage clearer and match up with the example.