### PR TITLE
Enable semantic coverage testing (w/ mutant) & refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,22 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['3.0', '3.2']
+    name: Ruby ${{ matrix.ruby }} Semantic Coverage (incremental)
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Verify mutation coverage
+        run: |
+          git fetch origin main --depth 1 --quiet # we need a reference for incremental mutation testing
+          bundle exec mutant run --since origin/main
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   coverage:

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,9 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in authorized_persona.gemspec
 gemspec
+
+group :development, :test do
+  source 'https://oss:Nkxjc1w4bjazfF068SSmDGoxZqLTVsFk@gem.mutant.dev' do
+    gem 'mutant-license'
+  end
+end

--- a/README.md
+++ b/README.md
@@ -227,4 +227,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the AuthorizedPersona project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/Betterment/authorized_persona/blob/master/CODE_OF_CONDUCT.md).
+Everyone interacting in the AuthorizedPersona project’s codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/Betterment/authorized_persona/blob/main/CODE_OF_CONDUCT.md).

--- a/authorized_persona.gemspec
+++ b/authorized_persona.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   rails_version_range = [">= 5.1.6.2", "< 7.1"]
 
@@ -30,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "betterlint"
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency 'mutant-rspec'
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/authorized_persona/authorization.rb
+++ b/lib/authorized_persona/authorization.rb
@@ -82,11 +82,11 @@ module AuthorizedPersona
                      "e.g. `authorize_persona class_name: 'User', current_user_method: :my_custom_current_user`"
       end
 
-      send(self.class.authorization_current_user_method)
+      public_send(authorization_current_user_method)
     end
 
     def authorized_tier
-      self.class.authorized_tier(action: params[:action])
+      self.class.authorized_tier(action: params.fetch(:action))
     end
 
     def authorize!

--- a/lib/authorized_persona/authorization.rb
+++ b/lib/authorized_persona/authorization.rb
@@ -82,7 +82,7 @@ module AuthorizedPersona
                      "e.g. `authorize_persona class_name: 'User', current_user_method: :my_custom_current_user`"
       end
 
-      public_send(authorization_current_user_method)
+      __send__(authorization_current_user_method)
     end
 
     def authorized_tier

--- a/lib/authorized_persona/persona.rb
+++ b/lib/authorized_persona/persona.rb
@@ -78,7 +78,7 @@ module AuthorizedPersona
 
     def authorization_tier_at_or_above?(target_tier)
       attr_name = public_send(self.class.authorization_tier_attribute_name)
-      self.class.send(:authorization_tier_level, attr_name) >= self.class.send(:authorization_tier_level, target_tier)
+      self.class.__send__(:authorization_tier_level, attr_name) >= self.class.__send__(:authorization_tier_level, target_tier)
     end
   end
 end

--- a/lib/authorized_persona/version.rb
+++ b/lib/authorized_persona/version.rb
@@ -1,3 +1,3 @@
 module AuthorizedPersona
-  VERSION = "0.9.1".freeze
+  VERSION = "0.10.0".freeze
 end

--- a/lib/authorized_persona/view_helpers.rb
+++ b/lib/authorized_persona/view_helpers.rb
@@ -2,7 +2,7 @@ module AuthorizedPersona
   module ViewHelpers
     def authorized_to?(action, resource)
       route = Rails.application.routes.named_routes[resource]
-      raise AuthorizedPersona::Error, "Unable to determine route for #{resource}" if route.nil?
+      raise Error, "Unable to determine route for #{resource}" if route.nil?
 
       controller_class = (route.defaults[:controller].camelize + 'Controller').constantize
       controller_class.authorized?(current_user: authorization_current_user, action: action)

--- a/lib/authorized_persona/view_helpers.rb
+++ b/lib/authorized_persona/view_helpers.rb
@@ -4,7 +4,7 @@ module AuthorizedPersona
       route = Rails.application.routes.named_routes[resource]
       raise Error, "Unable to determine route for #{resource}" if route.nil?
 
-      controller_class = (route.defaults[:controller].camelize + 'Controller').constantize
+      controller_class = (route.defaults.fetch(:controller).camelize + 'Controller').constantize
       controller_class.authorized?(current_user: authorization_current_user, action: action)
     end
   end

--- a/mutant.yml
+++ b/mutant.yml
@@ -1,0 +1,12 @@
+---
+integration:
+  name: rspec
+requires:
+  - authorized_persona
+matcher:
+  subjects:
+    - AuthorizedPersona*
+mutation:
+  timeout: 1.0
+coverage_criteria:
+  timeout: true

--- a/spec/authorized_persona/authorization_spec.rb
+++ b/spec/authorized_persona/authorization_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe AuthorizedPersona::Authorization do
       include AuthorizedPersona::Authorization
 
       attr_reader :current_user
+      private :current_user
 
       def initialize(current_user: nil, action: nil)
         @current_user = current_user

--- a/spec/authorized_persona/persona_spec.rb
+++ b/spec/authorized_persona/persona_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe AuthorizedPersona::Persona do
     end
   end
 
-  describe "#[tier]_or_above? and authorization_tier_at_or_above?" do
+  describe "#authorization_tier_at_or_above? and #[tier]_or_above?" do
     before do
       klass.authorization_tiers(
         trainee: "Trainee - limited access",
@@ -150,16 +150,19 @@ RSpec.describe AuthorizedPersona::Persona do
       it "is trainee_or_above" do
         expect(subject).to be_trainee_or_above
         expect(subject).to be_authorization_tier_at_or_above('trainee')
+        expect(subject.authorization_tier_at_or_above?('trainee')).to be(true)
       end
 
       it "is not staff_or_above" do
         expect(subject).not_to be_staff_or_above
         expect(subject).not_to be_authorization_tier_at_or_above('staff')
+        expect(subject.authorization_tier_at_or_above?('staff')).to be(false)
       end
 
       it "is not admin_or_above" do
         expect(subject).not_to be_admin_or_above
         expect(subject).not_to be_authorization_tier_at_or_above('admin')
+        expect(subject.authorization_tier_at_or_above?('admin')).to be(false)
       end
     end
 
@@ -169,16 +172,19 @@ RSpec.describe AuthorizedPersona::Persona do
       it "is trainee_or_above" do
         expect(subject).to be_trainee_or_above
         expect(subject).to be_authorization_tier_at_or_above('trainee')
+        expect(subject.authorization_tier_at_or_above?('trainee')).to be(true)
       end
 
       it "is staff_or_above" do
         expect(subject).to be_staff_or_above
         expect(subject).to be_authorization_tier_at_or_above('staff')
+        expect(subject.authorization_tier_at_or_above?('staff')).to be(true)
       end
 
       it "is admin_or_above" do
         expect(subject).to be_admin_or_above
         expect(subject).to be_authorization_tier_at_or_above('admin')
+        expect(subject.authorization_tier_at_or_above?('admin')).to be(true)
       end
     end
 

--- a/spec/authorized_persona/view_helpers_spec.rb
+++ b/spec/authorized_persona/view_helpers_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AuthorizedPersona::ViewHelpers do
   describe "#authorized_to?" do
     it "blows up if the route can't be located" do
       allow(rails_app.routes).to receive(:named_routes).and_return({})
-      expect { subject.authorized_to?(:create, :foo) }.to raise_error(/Unable to determine route/)
+      expect { subject.authorized_to?(:create, :foo) }.to raise_error(AuthorizedPersona::Error, /Unable to determine route for foo/)
     end
 
     it "blows up if it can't find a class matching the route's controller name" do

--- a/spec/authorized_persona/view_helpers_spec.rb
+++ b/spec/authorized_persona/view_helpers_spec.rb
@@ -26,11 +26,11 @@ RSpec.describe AuthorizedPersona::ViewHelpers do
   describe "#authorized_to?" do
     it "blows up if the route can't be located" do
       allow(rails_app.routes).to receive(:named_routes).and_return({})
-      expect { subject.authorized_to?(:create, :foo) }.to raise_error(AuthorizedPersona::Error, /Unable to determine route for foo/)
+      expect { subject.authorized_to?(:create, :foo) }.to raise_error(AuthorizedPersona::Error, 'Unable to determine route for foo')
     end
 
     it "blows up if it can't find a class matching the route's controller name" do
-      expect { subject.authorized_to?(:create, :foo) }.to raise_error(/uninitialized constant FoosController/)
+      expect { subject.authorized_to?(:create, :foo) }.to raise_error('uninitialized constant FoosController')
     end
 
     it "is authorized when the controller says so" do


### PR DESCRIPTION
This:
- adds `mutant-rspec` dependency
- adds semantic coverage workflow step
- Adds unit tests for untested `authorize!` (before_action) method & a couple other untested branches
- Reworks lib code to incorporate mutation-implied redundancy & API specificity improvements
- Bumps the version, since some lib code changes did occur

/domain @mbj @dkubb @samandmoore 
/platform @mbj @dkubb @samandmoore 